### PR TITLE
dutch language v1.1

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">DeepL</string>
+    <string name="image">Afbeelding</string>
+    <string name="copy_clipboard">Tekst is gekopieerd</string>
+    <string name="network_err">Oeps, geen verbinding met DeepL server</string>
+</resources>


### PR DESCRIPTION
> Since this project is under the MIT license, I would prefer not to include a copyleft type license if possible.
> Also, when I look at the copyright holder's name in the license, it seems to be someone else's name, not yours. I would like to know if there is any reason for this upside_down_face
> 
> If this is not the intended license, we would appreciate it if you could remove the license notation that was added in the pull request.

sorry for the late response but I never got a notification about your comment and I made a mistake with copying another file that's why there was a license.