### PR TITLE
Add android default translate context menu support (Android 10 and above)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,11 @@
             android:name=".FloatingTextSelection"
             android:theme="@style/WhiteTheme">
             <intent-filter>
+                <action android:name="android.intent.action.TRANSLATE" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/com/example/deeplviewer/FloatingTextSelection.kt
+++ b/app/src/main/java/com/example/deeplviewer/FloatingTextSelection.kt
@@ -9,10 +9,16 @@ class FloatingTextSelection : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            val floatingText = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()
+            val androidTranslateFloatingText = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                intent.getCharSequenceExtra(Intent.EXTRA_TEXT)
+            } else {
+                null
+            }
+
+            val floatingText = androidTranslateFloatingText ?: intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
 
             val intent = Intent(this, MainActivity::class.java)
-            intent.putExtra("FLOATING_TEXT", floatingText)
+            intent.putExtra("FLOATING_TEXT", floatingText?.toString())
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
             startActivity(intent)
             overridePendingTransition(0, 0)


### PR DESCRIPTION
Add android default translate context menu support (Android 10 and above).

This is a small commit, but it will allow you to change the default translation context in Android from Google Translate to DeepL Translator. This is very useful.

![Screenshot_20210905-024443321 (1)](https://user-images.githubusercontent.com/74596628/132103811-097e3c52-56b4-4ef3-b4fd-723298e8a6c5.jpg)

![Screenshot_20210905-024512057](https://user-images.githubusercontent.com/74596628/132103818-deba70dd-9225-4af5-aace-4ed556561df2.jpg)


After set default
![Screenshot_20210905-034000087 (1)](https://user-images.githubusercontent.com/74596628/132104833-0fb12f72-c6ef-473d-8d6b-a59b51e11a4b.jpg)


