### PR TITLE
Extract not translatable strings 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,10 +15,4 @@
     <string name="use_popup_mode">Use pop-up mode</string>
     <string name="about_this_app">About this app</string>
     <string name="version">Version</string>
-
-    <string name="key_dark_mode" translatable="false">defaultDarkMode</string>
-    <string name="key_switch_lang_button" translatable="false">isEnabledSwapLangButton</string>
-    <string name="key_switch_popup_mode" translatable="false">isEnabledPopupMode</string>
-    <string name="key_version" translatable="false">appVersion</string>
-    <string name="link_github_release" translatable="false">https://github.com/sakusaku3939/DeepLAndroid/releases</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <!-- Translatable strings used in our GUI. Non-translatable strings should be added to /values/strings_not_translatable.xml instead. -->
     <string name="app_name">DeepL</string>
     <string name="image">Image</string>
     <string name="copy_clipboard">Text has been Copied</string>

--- a/app/src/main/res/values/strings_not_translatable.xml
+++ b/app/src/main/res/values/strings_not_translatable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="key_dark_mode" translatable="false">defaultDarkMode</string>
+    <string name="key_switch_lang_button" translatable="false">isEnabledSwapLangButton</string>
+    <string name="key_switch_popup_mode" translatable="false">isEnabledPopupMode</string>
+    <string name="key_version" translatable="false">appVersion</string>
+    <string name="link_github_release" translatable="false">https://github.com/sakusaku3939/DeepLAndroid/releases</string>
+</resources>

--- a/app/src/main/res/values/strings_not_translatable.xml
+++ b/app/src/main/res/values/strings_not_translatable.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Only not translatable strings should be added here -->
     <string name="key_dark_mode" translatable="false">defaultDarkMode</string>
     <string name="key_switch_lang_button" translatable="false">isEnabledSwapLangButton</string>
     <string name="key_switch_popup_mode" translatable="false">isEnabledPopupMode</string>


### PR DESCRIPTION
Extract not-translatable strings to a separate file, to avoid accidental copying of these strings while translating... (as happened in #47, #65, #68)